### PR TITLE
Move reqwest stream feature to normal dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "1"
 futures = "0.3"
 http = "0.2"
 pin-project = "1"
-reqwest = { version = "0.11.7", features = ["json"] }
+reqwest = { version = "0.11.7", features = [ "json", "stream" ] }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 thiserror = "1"
@@ -26,9 +26,8 @@ tokio-tungstenite = { version = "0.17", features = [ "native-tls" ] }
 tokio-util = { version = "0.7.1", features = [ "codec", "io" ] }
 tungstenite = "0.17"
 url = "2"
-uuid = { version = "1", features = ["serde"] }
+uuid = { version = "1", features = [ "serde" ] }
 
 [dev-dependencies]
 cpal = "0.13"
 crossbeam = "0.8"
-reqwest = { version = "0.11.7", features = ["stream"] }


### PR DESCRIPTION
Previously it was just in the `dev-dependencies`, since it technically isn't needed to compile our library crate by itself.
However, it seems like it will be pretty common for people to want to send files, which requires the stream feature.

Users could enable the stream feature in their own dependencies, but since it's not obvious that that's the solution, it seems best to enable it here.