### PR TITLE
Upfront breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepgram"
-version = "0.1.1-alpha.2"
+version = "0.2.0-alpha.1"
 authors = ["Deepgram <developers@deepgram.com>"]
 edition = "2021"
 description = "Official Rust SDK for Deepgram's automated speech recognition APIs."

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can learn more about the full Deepgram API at [developers.deepgram.com](http
 Add the following line to the `dependencies` table in your `Cargo.toml` file:
 
 ```
-deepgram = "0.1.1-alpha.2"
+deepgram = "0.2.0-alpha.1"
 ```
 
 ## Development and Contributing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,5 @@
 #![forbid(unsafe_code)]
-#![warn(
-    missing_copy_implementations,
-    missing_debug_implementations,
-    clippy::cargo
-)]
+#![warn(missing_debug_implementations, clippy::cargo)]
 #![allow(clippy::multiple_crate_versions)]
 
 use std::io;

--- a/src/prerecorded/response.rs
+++ b/src/prerecorded/response.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 /// [api]: https://developers.deepgram.com/api-reference/#transcription-prerecorded
 #[allow(missing_docs)] // Struct fields are documented in the API reference
 #[derive(Debug, PartialEq, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct Response {
     pub metadata: ListenMetadata,
     pub results: ListenResults,
@@ -20,6 +21,7 @@ pub struct Response {
 /// [docs]: https://developers.deepgram.com/documentation/features/callback/
 #[allow(missing_docs)] // Struct fields are documented in the API reference
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Deserialize)]
+#[non_exhaustive]
 pub struct CallbackResponse {
     pub request_id: Uuid,
 }
@@ -31,6 +33,7 @@ pub struct CallbackResponse {
 /// [api]: https://developers.deepgram.com/api-reference/#transcription-prerecorded
 #[allow(missing_docs)] // Struct fields are documented in the API reference
 #[derive(Debug, PartialEq, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct ListenMetadata {
     pub request_id: Uuid,
     pub transaction_key: String,
@@ -47,6 +50,7 @@ pub struct ListenMetadata {
 /// [api]: https://developers.deepgram.com/api-reference/#transcription-prerecorded
 #[allow(missing_docs)] // Struct fields are documented in the API reference
 #[derive(Debug, PartialEq, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct ListenResults {
     pub channels: Vec<ChannelResult>,
 
@@ -66,6 +70,7 @@ pub struct ListenResults {
 /// [docs]: https://developers.deepgram.com/documentation/features/multichannel/
 #[allow(missing_docs)] // Struct fields are documented in the API reference
 #[derive(Debug, PartialEq, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct ChannelResult {
     /// [`None`] unless the [Search feature][docs] is set.
     /// Features can be set using an [`OptionsBuilder`](`super::OptionsBuilder`).
@@ -83,6 +88,7 @@ pub struct ChannelResult {
 /// [docs]: https://developers.deepgram.com/documentation/features/utterances/
 #[allow(missing_docs)] // Struct fields are documented in the API reference
 #[derive(Debug, PartialEq, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct Utterance {
     pub start: f64,
     pub end: f64,
@@ -109,6 +115,7 @@ pub struct Utterance {
 /// [docs]: https://developers.deepgram.com/documentation/features/search/
 #[allow(missing_docs)] // Struct fields are documented in the API reference
 #[derive(Debug, PartialEq, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct SearchResults {
     pub query: String,
     pub hits: Vec<Hit>,
@@ -121,6 +128,7 @@ pub struct SearchResults {
 /// [api]: https://developers.deepgram.com/api-reference/#transcription-prerecorded
 #[allow(missing_docs)] // Struct fields are documented in the API reference
 #[derive(Debug, PartialEq, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct ResultAlternative {
     pub transcript: String,
     pub confidence: f64,
@@ -134,6 +142,7 @@ pub struct ResultAlternative {
 /// [api]: https://developers.deepgram.com/api-reference/#transcription-prerecorded
 #[allow(missing_docs)] // Struct fields are documented in the API reference
 #[derive(Debug, PartialEq, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct Word {
     pub word: String,
     pub start: f64,
@@ -162,6 +171,7 @@ pub struct Word {
 /// [docs]: https://developers.deepgram.com/documentation/features/search/
 #[allow(missing_docs)] // Struct fields are documented in the API reference
 #[derive(Debug, PartialEq, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct Hit {
     pub confidence: f64,
     pub start: f64,

--- a/src/prerecorded/response.rs
+++ b/src/prerecorded/response.rs
@@ -20,7 +20,7 @@ pub struct Response {
 ///
 /// [docs]: https://developers.deepgram.com/documentation/features/callback/
 #[allow(missing_docs)] // Struct fields are documented in the API reference
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Deserialize)]
 #[non_exhaustive]
 pub struct CallbackResponse {
     pub request_id: Uuid,


### PR DESCRIPTION
Some breaking changes we can make in a release that's already going to be breaking (`0.1` -> `0.2`) so that once they become relevant, they won't cause a breaking update.

 - [x] Make structs that might get more fields in the future `#[non_exhaustive]`
 - [x] Remove the `Copy` trait from the aforementioned structs