### PR TITLE
Use String instead of &str where possible

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -150,11 +150,7 @@ impl<'a, K: AsRef<str>> Keys<'_, K> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn create(
-        &self,
-        project_id: &str,
-        options: &Options<'a>,
-    ) -> crate::Result<NewApiKey> {
+    pub async fn create(&self, project_id: &str, options: &Options) -> crate::Result<NewApiKey> {
         let url = format!("https://api.deepgram.com/v1/projects/{}/keys", project_id);
         let request = self
             .0

--- a/src/keys/options.rs
+++ b/src/keys/options.rs
@@ -228,15 +228,23 @@ impl OptionsBuilder {
 
 impl<'a> From<&'a Options> for SerializableOptions<'a> {
     fn from(options: &'a Options) -> Self {
+        // Destructuring it makes sure that we don't forget to use any of it
+        let Options {
+            comment,
+            tags,
+            scopes,
+            expiration,
+        } = options;
+
         let mut serializable_options = Self {
-            comment: &options.comment,
-            tags: &options.tags,
-            scopes: &options.scopes,
+            comment,
+            tags,
+            scopes,
             expiration_date: None,
             time_to_live_in_seconds: None,
         };
 
-        match &options.expiration {
+        match expiration {
             Some(Expiration::ExpirationDate(expiration_date)) => {
                 serializable_options.expiration_date = Some(expiration_date);
             }

--- a/src/keys/options.rs
+++ b/src/keys/options.rs
@@ -12,16 +12,16 @@ use serde::Serialize;
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#keys-create
 #[derive(Debug, PartialEq, Clone)]
-pub struct Options<'a> {
-    comment: &'a str,
-    tags: Vec<&'a str>,
-    scopes: Vec<&'a str>,
-    expiration: Option<Expiration<'a>>,
+pub struct Options {
+    comment: String,
+    tags: Vec<String>,
+    scopes: Vec<String>,
+    expiration: Option<Expiration>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
-enum Expiration<'a> {
-    ExpirationDate(&'a str),
+enum Expiration {
+    ExpirationDate(String),
     TimeToLiveInSeconds(usize),
 }
 
@@ -29,41 +29,41 @@ enum Expiration<'a> {
 ///
 /// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 #[derive(Debug, PartialEq, Clone)]
-pub struct OptionsBuilder<'a>(Options<'a>);
+pub struct OptionsBuilder(Options);
 
 #[derive(Serialize)]
 pub(super) struct SerializableOptions<'a> {
-    comment: &'a str,
+    comment: &'a String,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tags: &'a Vec<&'a str>,
+    tags: &'a Vec<String>,
 
-    scopes: &'a Vec<&'a str>,
+    scopes: &'a Vec<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    expiration_date: Option<&'a str>,
+    expiration_date: Option<&'a String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     time_to_live_in_seconds: Option<usize>,
 }
 
-impl<'a> Options<'a> {
+impl Options {
     /// Construct a new [`OptionsBuilder`].
-    pub fn builder(
-        comment: &'a str,
+    pub fn builder<'a>(
+        comment: impl Into<String>,
         scopes: impl IntoIterator<Item = &'a str>,
-    ) -> OptionsBuilder<'a> {
+    ) -> OptionsBuilder {
         OptionsBuilder::new(comment, scopes)
     }
 }
 
-impl<'a> OptionsBuilder<'a> {
+impl OptionsBuilder {
     /// Construct a new [`OptionsBuilder`].
-    pub fn new(comment: &'a str, scopes: impl IntoIterator<Item = &'a str>) -> Self {
+    pub fn new<'a>(comment: impl Into<String>, scopes: impl IntoIterator<Item = &'a str>) -> Self {
         Self(Options {
-            comment,
+            comment: comment.into(),
             tags: Vec::new(),
-            scopes: scopes.into_iter().collect(),
+            scopes: scopes.into_iter().map(String::from).collect(),
             expiration: None,
         })
     }
@@ -86,8 +86,8 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn comment(mut self, comment: &'a str) -> Self {
-        self.0.comment = comment;
+    pub fn comment(mut self, comment: impl Into<String>) -> Self {
+        self.0.comment = comment.into();
         self
     }
 
@@ -119,8 +119,8 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn tag(mut self, tags: impl IntoIterator<Item = &'a str>) -> Self {
-        self.0.tags.extend(tags);
+    pub fn tag<'a>(mut self, tags: impl IntoIterator<Item = &'a str>) -> Self {
+        self.0.tags.extend(tags.into_iter().map(String::from));
         self
     }
 
@@ -149,8 +149,8 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn scopes(mut self, scopes: impl IntoIterator<Item = &'a str>) -> Self {
-        self.0.scopes.extend(scopes);
+    pub fn scopes<'a>(mut self, scopes: impl IntoIterator<Item = &'a str>) -> Self {
+        self.0.scopes.extend(scopes.into_iter().map(String::from));
         self
     }
 
@@ -182,8 +182,8 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn expiration_date(mut self, expiration_date: &'a str) -> Self {
-        self.0.expiration = Some(Expiration::ExpirationDate(expiration_date));
+    pub fn expiration_date(mut self, expiration_date: impl Into<String>) -> Self {
+        self.0.expiration = Some(Expiration::ExpirationDate(expiration_date.into()));
         self
     }
 
@@ -221,27 +221,27 @@ impl<'a> OptionsBuilder<'a> {
     }
 
     /// Finish building the [`Options`] object.
-    pub fn build(self) -> Options<'a> {
+    pub fn build(self) -> Options {
         self.0
     }
 }
 
-impl<'a> From<&'a Options<'a>> for SerializableOptions<'a> {
-    fn from(options: &'a Options<'a>) -> Self {
+impl<'a> From<&'a Options> for SerializableOptions<'a> {
+    fn from(options: &'a Options) -> Self {
         let mut serializable_options = Self {
-            comment: options.comment,
+            comment: &options.comment,
             tags: &options.tags,
             scopes: &options.scopes,
             expiration_date: None,
             time_to_live_in_seconds: None,
         };
 
-        match options.expiration {
+        match &options.expiration {
             Some(Expiration::ExpirationDate(expiration_date)) => {
                 serializable_options.expiration_date = Some(expiration_date);
             }
             Some(Expiration::TimeToLiveInSeconds(time_to_live_in_seconds)) => {
-                serializable_options.time_to_live_in_seconds = Some(time_to_live_in_seconds);
+                serializable_options.time_to_live_in_seconds = Some(*time_to_live_in_seconds);
             }
             None => {}
         };

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -147,7 +147,7 @@ impl<'a, K: AsRef<str>> Projects<'_, K> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn update(&self, project_id: &str, options: &Options<'a>) -> crate::Result<Message> {
+    pub async fn update(&self, project_id: &str, options: &Options) -> crate::Result<Message> {
         let url = format!("https://api.deepgram.com/v1/projects/{}", project_id);
         let request = self
             .0

--- a/src/projects/options.rs
+++ b/src/projects/options.rs
@@ -11,35 +11,35 @@ use serde::Serialize;
 /// See the [Deepgram API Reference][api] for more info.
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#projects-update
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Options<'a> {
-    name: Option<&'a str>,
-    company: Option<&'a str>,
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct Options {
+    name: Option<String>,
+    company: Option<String>,
 }
 
 /// Builds an [`Options`] object using [the Builder pattern][builder].
 ///
 /// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 #[derive(Debug, PartialEq, Clone)]
-pub struct OptionsBuilder<'a>(Options<'a>);
+pub struct OptionsBuilder(Options);
 
 #[derive(Serialize)]
 pub(super) struct SerializableOptions<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) name: &'a Option<&'a str>,
+    pub(super) name: &'a Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) company: &'a Option<&'a str>,
+    pub(super) company: &'a Option<String>,
 }
 
-impl<'a> Options<'a> {
+impl Options {
     /// Construct a new [`OptionsBuilder`].
-    pub fn builder() -> OptionsBuilder<'a> {
+    pub fn builder() -> OptionsBuilder {
         OptionsBuilder::new()
     }
 }
 
-impl<'a> OptionsBuilder<'a> {
+impl OptionsBuilder {
     /// Construct a new [`OptionsBuilder`].
     pub fn new() -> Self {
         Self(Options {
@@ -59,8 +59,8 @@ impl<'a> OptionsBuilder<'a> {
     ///     .name("The Transcribinator")
     ///     .build();
     /// ```
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.0.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.0.name = Some(name.into());
         self
     }
 
@@ -75,25 +75,25 @@ impl<'a> OptionsBuilder<'a> {
     ///     .company("Doofenshmirtz Evil Incorporated")
     ///     .build();
     /// ```
-    pub fn company(mut self, company: &'a str) -> Self {
-        self.0.company = Some(company);
+    pub fn company(mut self, company: impl Into<String>) -> Self {
+        self.0.company = Some(company.into());
         self
     }
 
     /// Finish building the [`Options`] object.
-    pub fn build(self) -> Options<'a> {
+    pub fn build(self) -> Options {
         self.0
     }
 }
 
-impl<'a> Default for OptionsBuilder<'a> {
+impl Default for OptionsBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a> From<&'a Options<'a>> for SerializableOptions<'a> {
-    fn from(options: &'a Options<'a>) -> Self {
+impl<'a> From<&'a Options> for SerializableOptions<'a> {
+    fn from(options: &'a Options) -> Self {
         Self {
             name: &options.name,
             company: &options.company,

--- a/src/projects/options.rs
+++ b/src/projects/options.rs
@@ -94,9 +94,9 @@ impl Default for OptionsBuilder {
 
 impl<'a> From<&'a Options> for SerializableOptions<'a> {
     fn from(options: &'a Options) -> Self {
-        Self {
-            name: &options.name,
-            company: &options.company,
-        }
+        // Destructuring it makes sure that we don't forget to use any of it
+        let Options { name, company } = options;
+
+        Self { name, company }
     }
 }

--- a/src/transcription/prerecorded.rs
+++ b/src/transcription/prerecorded.rs
@@ -67,7 +67,7 @@ impl<K: AsRef<str>> Transcription<'_, K> {
     pub async fn prerecorded(
         &self,
         source: AudioSource,
-        options: &Options<'_>,
+        options: &Options,
     ) -> crate::Result<Response> {
         let request_builder = self.make_prerecorded_request_builder(source, options);
 
@@ -124,7 +124,7 @@ impl<K: AsRef<str>> Transcription<'_, K> {
     pub async fn prerecorded_callback(
         &self,
         source: AudioSource,
-        options: &Options<'_>,
+        options: &Options,
         callback: &str,
     ) -> crate::Result<CallbackResponse> {
         let request_builder =
@@ -190,7 +190,7 @@ impl<K: AsRef<str>> Transcription<'_, K> {
     pub fn make_prerecorded_request_builder(
         &self,
         source: AudioSource,
-        options: &Options<'_>,
+        options: &Options,
     ) -> RequestBuilder {
         let request_builder = self
             .0
@@ -261,7 +261,7 @@ impl<K: AsRef<str>> Transcription<'_, K> {
     pub fn make_prerecorded_callback_request_builder(
         &self,
         source: AudioSource,
-        options: &Options<'_>,
+        options: &Options,
         callback: &str,
     ) -> RequestBuilder {
         self.make_prerecorded_request_builder(source, options)

--- a/src/transcription/prerecorded/options.rs
+++ b/src/transcription/prerecorded/options.rs
@@ -46,7 +46,7 @@ pub enum Tier {
 
 /// Used as a parameter for [`OptionsBuilder::model`] and [`OptionsBuilder::multichannel_with_models`].
 ///
-/// See the [Deepgram Tier feature docs][docs] for more info.
+/// See the [Deepgram Model feature docs][docs] for more info.
 ///
 /// [docs]: https://developers.deepgram.com/documentation/features/model/
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]

--- a/src/transcription/prerecorded/options.rs
+++ b/src/transcription/prerecorded/options.rs
@@ -761,7 +761,7 @@ impl OptionsBuilder {
     /// assert_eq!(options1, options2);
     /// ```
     pub fn search<'a>(mut self, search: impl IntoIterator<Item = &'a str>) -> Self {
-        self.0.search.extend(search.into_iter().map(|s| s.into()));
+        self.0.search.extend(search.into_iter().map(String::from));
         self
     }
 
@@ -1048,7 +1048,7 @@ impl OptionsBuilder {
     /// assert_eq!(options1, options2);
     /// ```
     pub fn tag<'a>(mut self, tag: impl IntoIterator<Item = &'a str>) -> Self {
-        self.0.tags.extend(tag.into_iter().map(|s| s.into()));
+        self.0.tags.extend(tag.into_iter().map(String::from));
         self
     }
 

--- a/src/transcription/prerecorded/options.rs
+++ b/src/transcription/prerecorded/options.rs
@@ -8,25 +8,25 @@ use serde::{ser::SerializeSeq, Serialize};
 
 /// Used as a parameter for [`Transcription::prerecorded`](crate::transcription::Transcription::prerecorded) and similar functions.
 #[derive(Debug, PartialEq, Clone)]
-pub struct Options<'a> {
+pub struct Options {
     tier: Option<Tier>,
-    model: Option<Model<'a>>,
-    version: Option<&'a str>,
-    language: Option<Language<'a>>,
+    model: Option<Model>,
+    version: Option<String>,
+    language: Option<Language>,
     punctuate: Option<bool>,
     profanity_filter: Option<bool>,
-    redact: Vec<Redact<'a>>,
+    redact: Vec<Redact>,
     diarize: Option<bool>,
     ner: Option<bool>,
-    multichannel: Option<Multichannel<'a>>,
+    multichannel: Option<Multichannel>,
     alternatives: Option<usize>,
     numerals: Option<bool>,
-    search: Vec<&'a str>,
-    replace: Vec<Replace<'a>>,
-    keywords: Vec<Keyword<'a>>,
+    search: Vec<String>,
+    replace: Vec<Replace>,
+    keywords: Vec<Keyword>,
     keyword_boost_legacy: bool,
     utterances: Option<Utterances>,
-    tags: Vec<&'a str>,
+    tags: Vec<String>,
 }
 
 /// Used as a parameter for [`OptionsBuilder::tier`].
@@ -46,12 +46,12 @@ pub enum Tier {
 
 /// Used as a parameter for [`OptionsBuilder::model`] and [`OptionsBuilder::multichannel_with_models`].
 ///
-/// See the [Deepgram Model feature docs][docs] for more info.
+/// See the [Deepgram Tier feature docs][docs] for more info.
 ///
 /// [docs]: https://developers.deepgram.com/documentation/features/model/
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 #[non_exhaustive]
-pub enum Model<'a> {
+pub enum Model {
     #[allow(missing_docs)]
     General,
 
@@ -74,7 +74,7 @@ pub enum Model<'a> {
     Video,
 
     #[allow(missing_docs)]
-    CustomId(&'a str),
+    CustomId(String),
 }
 
 /// Used as a parameter for [`OptionsBuilder::language`].
@@ -83,9 +83,9 @@ pub enum Model<'a> {
 ///
 /// [docs]: https://developers.deepgram.com/documentation/features/language/
 #[allow(non_camel_case_types)] // Variants should look like their BCP-47 tag
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 #[non_exhaustive]
-pub enum Language<'a> {
+pub enum Language {
     #[allow(missing_docs)]
     zh,
 
@@ -172,7 +172,7 @@ pub enum Language<'a> {
     /// See the [Deepgram Language feature docs][docs] for the most up-to-date list of supported languages.
     ///
     /// [docs]: https://developers.deepgram.com/documentation/features/language/
-    Other(&'a str),
+    Other(String),
 }
 
 /// Used as a parameter for [`OptionsBuilder::redact`].
@@ -180,9 +180,9 @@ pub enum Language<'a> {
 /// See the [Deepgram Redaction feature docs][docs] for more info.
 ///
 /// [docs]: https://developers.deepgram.com/documentation/features/redact/
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 #[non_exhaustive]
-pub enum Redact<'a> {
+pub enum Redact {
     #[allow(missing_docs)]
     Pci,
 
@@ -197,7 +197,7 @@ pub enum Redact<'a> {
     /// See the [Deepgram Redact feature docs][docs] for the most up-to-date list of redactable items.
     ///
     /// [docs]: https://developers.deepgram.com/documentation/features/redact/
-    Other(&'a str),
+    Other(String),
 }
 
 /// Used as a parameter for [`OptionsBuilder::replace`].
@@ -205,14 +205,14 @@ pub enum Redact<'a> {
 /// See the [Deepgram Find and Replace feature docs][docs] for more info.
 ///
 /// [docs]: https://developers.deepgram.com/documentation/features/replace/
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct Replace<'a> {
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct Replace {
     /// The term or phrase to find.
-    pub find: &'a str,
+    pub find: String,
 
     /// The term or phrase to replace [`find`](Replace::find) with.
     /// If set to [`None`], [`find`](Replace::find) will be removed from the transcript without being replaced by anything.
-    pub replace: Option<&'a str>,
+    pub replace: Option<String>,
 }
 
 /// Used as a parameter for [`OptionsBuilder::keywords_with_intensifiers`].
@@ -220,10 +220,10 @@ pub struct Replace<'a> {
 /// See the [Deepgram Keywords feature docs][docs] for more info.
 ///
 /// [docs]: https://developers.deepgram.com/documentation/features/keywords/
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub struct Keyword<'a> {
+#[derive(Debug, PartialEq, Clone)]
+pub struct Keyword {
     /// The keyword to boost.
-    pub keyword: &'a str,
+    pub keyword: String,
 
     /// Optionally specify how much to boost it.
     pub intensifier: Option<f64>,
@@ -236,9 +236,9 @@ enum Utterances {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-enum Multichannel<'a> {
+enum Multichannel {
     Disabled,
-    Enabled { models: Option<Vec<Model<'a>>> },
+    Enabled { models: Option<Vec<Model>> },
 }
 
 /// Builds an [`Options`] object using [the Builder pattern][builder].
@@ -248,19 +248,19 @@ enum Multichannel<'a> {
 ///
 /// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 #[derive(Debug, PartialEq, Clone)]
-pub struct OptionsBuilder<'a>(Options<'a>);
+pub struct OptionsBuilder(Options);
 
 #[derive(Debug, PartialEq, Clone)]
-pub(super) struct SerializableOptions<'a>(pub(super) &'a Options<'a>);
+pub(super) struct SerializableOptions<'a>(pub(super) &'a Options);
 
-impl<'a> Options<'a> {
+impl Options {
     /// Construct a new [`OptionsBuilder`].
-    pub fn builder() -> OptionsBuilder<'a> {
+    pub fn builder() -> OptionsBuilder {
         OptionsBuilder::new()
     }
 }
 
-impl<'a> OptionsBuilder<'a> {
+impl OptionsBuilder {
     /// Construct a new [`OptionsBuilder`].
     pub fn new() -> Self {
         Self(Options {
@@ -348,7 +348,7 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn model(mut self, model: Model<'a>) -> Self {
+    pub fn model(mut self, model: Model) -> Self {
         self.0.model = Some(model);
 
         if let Some(Multichannel::Enabled { models }) = &mut self.0.multichannel {
@@ -373,8 +373,8 @@ impl<'a> OptionsBuilder<'a> {
     ///     .version("12345678-1234-1234-1234-1234567890ab")
     ///     .build();
     /// ```
-    pub fn version(mut self, version: &'a str) -> Self {
-        self.0.version = Some(version);
+    pub fn version(mut self, version: &str) -> Self {
+        self.0.version = Some(version.into());
         self
     }
 
@@ -393,7 +393,7 @@ impl<'a> OptionsBuilder<'a> {
     ///     .language(Language::en_US)
     ///     .build();
     /// ```
-    pub fn language(mut self, language: Language<'a>) -> Self {
+    pub fn language(mut self, language: Language) -> Self {
         self.0.language = Some(language);
         self
     }
@@ -474,7 +474,7 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn redact(mut self, redact: impl IntoIterator<Item = Redact<'a>>) -> Self {
+    pub fn redact(mut self, redact: impl IntoIterator<Item = Redact>) -> Self {
         self.0.redact.extend(redact);
         self
     }
@@ -668,7 +668,7 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn multichannel_with_models(mut self, models: impl IntoIterator<Item = Model<'a>>) -> Self {
+    pub fn multichannel_with_models(mut self, models: impl IntoIterator<Item = Model>) -> Self {
         if let Some(Multichannel::Enabled {
             models: Some(old_models),
         }) = &mut self.0.multichannel
@@ -760,8 +760,8 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn search(mut self, search: impl IntoIterator<Item = &'a str>) -> Self {
-        self.0.search.extend(search);
+    pub fn search<'a>(mut self, search: impl IntoIterator<Item = &'a str>) -> Self {
+        self.0.search.extend(search.into_iter().map(|s| s.into()));
         self
     }
 
@@ -781,11 +781,11 @@ impl<'a> OptionsBuilder<'a> {
     /// let options = Options::builder()
     ///     .replace([
     ///         Replace {
-    ///             find: "Aaron",
-    ///             replace: Some("Erin"),
+    ///             find: String::from("Aaron"),
+    ///             replace: Some(String::from("Erin")),
     ///         },
     ///         Replace {
-    ///             find: "Voldemort",
+    ///             find: String::from("Voldemort"),
     ///             replace: None,
     ///         },
     ///     ])
@@ -797,11 +797,11 @@ impl<'a> OptionsBuilder<'a> {
     /// #
     /// let options1 = Options::builder()
     ///     .replace([Replace {
-    ///         find: "Aaron",
-    ///         replace: Some("Erin"),
+    ///         find: String::from("Aaron"),
+    ///         replace: Some(String::from("Erin")),
     ///     }])
     ///     .replace([Replace {
-    ///         find: "Voldemort",
+    ///         find: String::from("Voldemort"),
     ///         replace: None,
     ///     }])
     ///     .build();
@@ -809,11 +809,11 @@ impl<'a> OptionsBuilder<'a> {
     /// let options2 = Options::builder()
     ///     .replace([
     ///         Replace {
-    ///             find: "Aaron",
-    ///             replace: Some("Erin"),
+    ///             find: String::from("Aaron"),
+    ///             replace: Some(String::from("Erin")),
     ///         },
     ///         Replace {
-    ///             find: "Voldemort",
+    ///             find: String::from("Voldemort"),
     ///             replace: None,
     ///         },
     ///     ])
@@ -821,7 +821,7 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn replace(mut self, replace: impl IntoIterator<Item = Replace<'a>>) -> Self {
+    pub fn replace(mut self, replace: impl IntoIterator<Item = Replace>) -> Self {
         self.0.replace.extend(replace);
         self
     }
@@ -861,9 +861,9 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn keywords(mut self, keywords: impl IntoIterator<Item = &'a str>) -> Self {
+    pub fn keywords<'a>(mut self, keywords: impl IntoIterator<Item = &'a str>) -> Self {
         let iter = keywords.into_iter().map(|keyword| Keyword {
-            keyword,
+            keyword: keyword.into(),
             intensifier: None,
         });
 
@@ -889,11 +889,11 @@ impl<'a> OptionsBuilder<'a> {
     /// let options = Options::builder()
     ///     .keywords_with_intensifiers([
     ///         Keyword {
-    ///             keyword: "hello",
+    ///             keyword: String::from("hello"),
     ///             intensifier: Some(-1.5),
     ///         },
     ///         Keyword {
-    ///             keyword: "world",
+    ///             keyword: String::from("world"),
     ///             intensifier: None,
     ///         },
     ///     ])
@@ -906,13 +906,13 @@ impl<'a> OptionsBuilder<'a> {
     /// let options1 = Options::builder()
     ///     .keywords_with_intensifiers([
     ///         Keyword {
-    ///             keyword: "hello",
+    ///             keyword: String::from("hello"),
     ///             intensifier: Some(-1.5),
     ///         },
     ///     ])
     ///     .keywords_with_intensifiers([
     ///         Keyword {
-    ///             keyword: "world",
+    ///             keyword: String::from("world"),
     ///             intensifier: None,
     ///         },
     ///     ])
@@ -921,11 +921,11 @@ impl<'a> OptionsBuilder<'a> {
     /// let options2 = Options::builder()
     ///     .keywords_with_intensifiers([
     ///         Keyword {
-    ///             keyword: "hello",
+    ///             keyword: String::from("hello"),
     ///             intensifier: Some(-1.5),
     ///         },
     ///         Keyword {
-    ///             keyword: "world",
+    ///             keyword: String::from("world"),
     ///             intensifier: None,
     ///         },
     ///     ])
@@ -935,7 +935,7 @@ impl<'a> OptionsBuilder<'a> {
     /// ```
     pub fn keywords_with_intensifiers(
         mut self,
-        keywords: impl IntoIterator<Item = Keyword<'a>>,
+        keywords: impl IntoIterator<Item = Keyword>,
     ) -> Self {
         self.0.keywords.extend(keywords);
         self
@@ -1047,18 +1047,18 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn tag(mut self, tag: impl IntoIterator<Item = &'a str>) -> Self {
-        self.0.tags.extend(tag);
+    pub fn tag<'a>(mut self, tag: impl IntoIterator<Item = &'a str>) -> Self {
+        self.0.tags.extend(tag.into_iter().map(|s| s.into()));
         self
     }
 
     /// Finish building the [`Options`] object.
-    pub fn build(self) -> Options<'a> {
+    pub fn build(self) -> Options {
         self.0
     }
 }
 
-impl Default for OptionsBuilder<'_> {
+impl Default for OptionsBuilder {
     fn default() -> Self {
         Self::new()
     }
@@ -1166,10 +1166,10 @@ impl Serialize for SerializableOptions<'_> {
         }
 
         for element in replace {
-            if let Some(replace) = element.replace {
+            if let Some(replace) = &element.replace {
                 seq.serialize_element(&("replace", format!("{}:{}", element.find, replace)))?;
             } else {
-                seq.serialize_element(&("replace", element.find))?;
+                seq.serialize_element(&("replace", &element.find))?;
             }
         }
 
@@ -1180,7 +1180,7 @@ impl Serialize for SerializableOptions<'_> {
                     format!("{}:{}", element.keyword, intensifier),
                 ))?;
             } else {
-                seq.serialize_element(&("keywords", element.keyword))?;
+                seq.serialize_element(&("keywords", &element.keyword))?;
             }
         }
 
@@ -1219,7 +1219,7 @@ impl AsRef<str> for Tier {
     }
 }
 
-impl AsRef<str> for Model<'_> {
+impl AsRef<str> for Model {
     fn as_ref(&self) -> &str {
         use Model::*;
 
@@ -1236,7 +1236,7 @@ impl AsRef<str> for Model<'_> {
     }
 }
 
-impl AsRef<str> for Language<'_> {
+impl AsRef<str> for Language {
     fn as_ref(&self) -> &str {
         use Language::*;
 
@@ -1273,7 +1273,7 @@ impl AsRef<str> for Language<'_> {
     }
 }
 
-impl AsRef<str> for Redact<'_> {
+impl AsRef<str> for Redact {
     fn as_ref(&self) -> &str {
         use Redact::*;
 
@@ -1319,7 +1319,11 @@ mod models_to_string_tests {
     #[test]
     fn custom() {
         assert_eq!(
-            models_to_string(&[Finance, CustomId("extra_crispy"), Conversationalai]),
+            models_to_string(&[
+                Finance,
+                CustomId(String::from("extra_crispy")),
+                Conversationalai
+            ]),
             "finance:extra_crispy:conversationalai"
         );
     }
@@ -1380,19 +1384,19 @@ mod serialize_options_tests {
             .ner(true)
             .multichannel_with_models([
                 Model::Finance,
-                Model::CustomId("extra_crispy"),
+                Model::CustomId(String::from("extra_crispy")),
                 Model::Conversationalai,
             ])
             .alternatives(4)
             .numerals(true)
             .search(["Rust", "Deepgram"])
             .replace([Replace {
-                find: "Aaron",
-                replace: Some("Erin"),
+                find: String::from("Aaron"),
+                replace: Some(String::from("Erin")),
             }])
             .keywords(["Ferris"])
             .keywords_with_intensifiers([Keyword {
-                keyword: "Cargo",
+                keyword: String::from("Cargo"),
                 intensifier: Some(-1.5),
             }])
             .utterances_with_utt_split(0.9)
@@ -1421,7 +1425,7 @@ mod serialize_options_tests {
 
         check_serialization(
             &Options::builder()
-                .model(Model::CustomId("extra_crispy"))
+                .model(Model::CustomId(String::from("extra_crispy")))
                 .build(),
             "model=extra_crispy",
         );
@@ -1535,7 +1539,7 @@ mod serialize_options_tests {
             &Options::builder()
                 .multichannel_with_models([
                     Model::Finance,
-                    Model::CustomId("extra_crispy"),
+                    Model::CustomId(String::from("extra_crispy")),
                     Model::Conversationalai,
                 ])
                 .build(),
@@ -1585,8 +1589,8 @@ mod serialize_options_tests {
         check_serialization(
             &Options::builder()
                 .replace([Replace {
-                    find: "Aaron",
-                    replace: Some("Erin"),
+                    find: String::from("Aaron"),
+                    replace: Some(String::from("Erin")),
                 }])
                 .build(),
             "replace=Aaron%3AErin",
@@ -1595,7 +1599,7 @@ mod serialize_options_tests {
         check_serialization(
             &Options::builder()
                 .replace([Replace {
-                    find: "Voldemort",
+                    find: String::from("Voldemort"),
                     replace: None,
                 }])
                 .build(),
@@ -1606,11 +1610,11 @@ mod serialize_options_tests {
             &Options::builder()
                 .replace([
                     Replace {
-                        find: "Aaron",
-                        replace: Some("Erin"),
+                        find: String::from("Aaron"),
+                        replace: Some(String::from("Erin")),
                     },
                     Replace {
-                        find: "Voldemort",
+                        find: String::from("Voldemort"),
                         replace: None,
                     },
                 ])
@@ -1621,8 +1625,8 @@ mod serialize_options_tests {
         check_serialization(
             &Options::builder()
                 .replace([Replace {
-                    find: "this too",
-                    replace: Some("that too"),
+                    find: String::from("this too"),
+                    replace: Some(String::from("that too")),
                 }])
                 .build(),
             "replace=this+too%3Athat+too",
@@ -1651,7 +1655,7 @@ mod serialize_options_tests {
 
         {
             let keywords = [Keyword {
-                keyword: "Ferris",
+                keyword: String::from("Ferris"),
                 intensifier: Some(0.5),
             }];
 
@@ -1666,11 +1670,11 @@ mod serialize_options_tests {
         {
             let keywords = [
                 Keyword {
-                    keyword: "Ferris",
+                    keyword: String::from("Ferris"),
                     intensifier: Some(0.5),
                 },
                 Keyword {
-                    keyword: "Cargo",
+                    keyword: String::from("Cargo"),
                     intensifier: Some(-1.5),
                 },
             ];

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -175,7 +175,7 @@ impl<'a, K: AsRef<str>> Usage<'_, K> {
     pub async fn get_usage(
         &self,
         project_id: &str,
-        options: &get_usage_options::Options<'a>,
+        options: &get_usage_options::Options,
     ) -> crate::Result<UsageSummary> {
         let url = format!("https://api.deepgram.com/v1/projects/{}/usage", project_id);
         let request = self

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -76,7 +76,7 @@ impl<'a, K: AsRef<str>> Usage<'_, K> {
     pub async fn list_requests(
         &self,
         project_id: &str,
-        options: &list_requests_options::Options<'a>,
+        options: &list_requests_options::Options,
     ) -> crate::Result<Requests> {
         let url = format!(
             "https://api.deepgram.com/v1/projects/{}/requests",

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -225,7 +225,7 @@ impl<'a, K: AsRef<str>> Usage<'_, K> {
     pub async fn get_fields(
         &self,
         project_id: &str,
-        options: &get_fields_options::Options<'a>,
+        options: &get_fields_options::Options,
     ) -> crate::Result<Fields> {
         let url = format!(
             "https://api.deepgram.com/v1/projects/{}/usage/fields",

--- a/src/usage/get_fields_options.rs
+++ b/src/usage/get_fields_options.rs
@@ -94,9 +94,9 @@ impl Default for OptionsBuilder {
 
 impl<'a> From<&'a Options> for SerializableOptions<'a> {
     fn from(options: &'a Options) -> Self {
-        Self {
-            start: &options.start,
-            end: &options.end,
-        }
+        // Destructuring it makes sure that we don't forget to use any of it
+        let Options { start, end } = options;
+
+        Self { start, end }
     }
 }

--- a/src/usage/get_fields_options.rs
+++ b/src/usage/get_fields_options.rs
@@ -12,34 +12,34 @@ use serde::Serialize;
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#usage-fields
 #[derive(Debug, PartialEq, Clone)]
-pub struct Options<'a> {
-    start: Option<&'a str>,
-    end: Option<&'a str>,
+pub struct Options {
+    start: Option<String>,
+    end: Option<String>,
 }
 
 /// Builds an [`Options`] object using [the Builder pattern][builder].
 ///
 /// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 #[derive(Debug, PartialEq, Clone)]
-pub struct OptionsBuilder<'a>(Options<'a>);
+pub struct OptionsBuilder(Options);
 
 #[derive(Serialize)]
 pub(super) struct SerializableOptions<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    start: Option<&'a str>,
+    start: &'a Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    end: Option<&'a str>,
+    end: &'a Option<String>,
 }
 
-impl<'a> Options<'a> {
+impl Options {
     /// Construct a new [`OptionsBuilder`].
-    pub fn builder() -> OptionsBuilder<'a> {
+    pub fn builder() -> OptionsBuilder {
         OptionsBuilder::new()
     }
 }
 
-impl<'a> OptionsBuilder<'a> {
+impl OptionsBuilder {
     /// Construct a new [`OptionsBuilder`].
     pub fn new() -> Self {
         Self(Options {
@@ -59,8 +59,8 @@ impl<'a> OptionsBuilder<'a> {
     ///     .start("1970-01-01")
     ///     .build();
     /// ```
-    pub fn start(mut self, start: &'a str) -> Self {
-        self.0.start = Some(start);
+    pub fn start(mut self, start: impl Into<String>) -> Self {
+        self.0.start = Some(start.into());
         self
     }
 
@@ -75,28 +75,28 @@ impl<'a> OptionsBuilder<'a> {
     ///     .end("2038-01-19")
     ///     .build();
     /// ```
-    pub fn end(mut self, end: &'a str) -> Self {
-        self.0.end = Some(end);
+    pub fn end(mut self, end: impl Into<String>) -> Self {
+        self.0.end = Some(end.into());
         self
     }
 
     /// Finish building the [`Options`] object.
-    pub fn build(self) -> Options<'a> {
+    pub fn build(self) -> Options {
         self.0
     }
 }
 
-impl Default for OptionsBuilder<'_> {
+impl Default for OptionsBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a> From<&'a Options<'a>> for SerializableOptions<'a> {
-    fn from(options: &'a Options<'a>) -> Self {
+impl<'a> From<&'a Options> for SerializableOptions<'a> {
+    fn from(options: &'a Options) -> Self {
         Self {
-            start: options.start,
-            end: options.end,
+            start: &options.start,
+            end: &options.end,
         }
     }
 }

--- a/src/usage/get_usage_options.rs
+++ b/src/usage/get_usage_options.rs
@@ -12,13 +12,13 @@ use serde::{ser::SerializeSeq, Serialize};
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#usage-summary
 #[derive(Debug, PartialEq, Clone)]
-pub struct Options<'a> {
-    start: Option<&'a str>,
-    end: Option<&'a str>,
-    accessor: Option<&'a str>,
-    tags: Vec<&'a str>,
+pub struct Options {
+    start: Option<String>,
+    end: Option<String>,
+    accessor: Option<String>,
+    tags: Vec<String>,
     methods: Vec<Method>,
-    models: Vec<&'a str>,
+    models: Vec<String>,
     multichannel: Option<bool>,
     interim_results: Option<bool>,
     punctuate: Option<bool>,
@@ -52,18 +52,18 @@ pub enum Method {
 ///
 /// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 #[derive(Debug, PartialEq, Clone)]
-pub struct OptionsBuilder<'a>(Options<'a>);
+pub struct OptionsBuilder(Options);
 
-pub(super) struct SerializableOptions<'a>(&'a Options<'a>);
+pub(super) struct SerializableOptions<'a>(&'a Options);
 
-impl<'a> Options<'a> {
+impl Options {
     /// Construct a new [`OptionsBuilder`].
-    pub fn builder() -> OptionsBuilder<'a> {
+    pub fn builder() -> OptionsBuilder {
         OptionsBuilder::new()
     }
 }
 
-impl<'a> OptionsBuilder<'a> {
+impl OptionsBuilder {
     /// Construct a new [`OptionsBuilder`].
     pub fn new() -> Self {
         Self(Options {
@@ -100,8 +100,8 @@ impl<'a> OptionsBuilder<'a> {
     ///     .start("1970-01-01")
     ///     .build();
     /// ```
-    pub fn start(mut self, start: &'a str) -> Self {
-        self.0.start = Some(start);
+    pub fn start(mut self, start: impl Into<String>) -> Self {
+        self.0.start = Some(start.into());
         self
     }
 
@@ -116,8 +116,8 @@ impl<'a> OptionsBuilder<'a> {
     ///     .end("2038-01-19")
     ///     .build();
     /// ```
-    pub fn end(mut self, end: &'a str) -> Self {
-        self.0.end = Some(end);
+    pub fn end(mut self, end: impl Into<String>) -> Self {
+        self.0.end = Some(end.into());
         self
     }
 
@@ -132,8 +132,8 @@ impl<'a> OptionsBuilder<'a> {
     ///     .accessor("12345678-1234-1234-1234-1234567890ab")
     ///     .build();
     /// ```
-    pub fn accessor(mut self, accessor: &'a str) -> Self {
-        self.0.accessor = Some(accessor);
+    pub fn accessor(mut self, accessor: impl Into<String>) -> Self {
+        self.0.accessor = Some(accessor.into());
         self
     }
 
@@ -165,8 +165,8 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn tag(mut self, tag: impl IntoIterator<Item = &'a str>) -> Self {
-        self.0.tags.extend(tag);
+    pub fn tag<'a>(mut self, tag: impl IntoIterator<Item = &'a str>) -> Self {
+        self.0.tags.extend(tag.into_iter().map(String::from));
         self
     }
 
@@ -237,8 +237,8 @@ impl<'a> OptionsBuilder<'a> {
     ///
     /// assert_eq!(options1, options2);
     /// ```
-    pub fn model(mut self, model: impl IntoIterator<Item = &'a str>) -> Self {
-        self.0.models.extend(model);
+    pub fn model<'a>(mut self, model: impl IntoIterator<Item = &'a str>) -> Self {
+        self.0.models.extend(model.into_iter().map(String::from));
         self
     }
 
@@ -451,19 +451,19 @@ impl<'a> OptionsBuilder<'a> {
     }
 
     /// Finish building the [`Options`] object.
-    pub fn build(self) -> Options<'a> {
+    pub fn build(self) -> Options {
         self.0
     }
 }
 
-impl Default for OptionsBuilder<'_> {
+impl Default for OptionsBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a> From<&'a Options<'a>> for SerializableOptions<'a> {
-    fn from(options: &'a Options<'a>) -> Self {
+impl<'a> From<&'a Options> for SerializableOptions<'a> {
+    fn from(options: &'a Options) -> Self {
         Self(options)
     }
 }

--- a/src/usage/list_requests_options.rs
+++ b/src/usage/list_requests_options.rs
@@ -147,11 +147,19 @@ impl Default for OptionsBuilder {
 
 impl<'a> From<&'a Options> for SerializableOptions<'a> {
     fn from(options: &'a Options) -> Self {
+        // Destructuring it makes sure that we don't forget to use any of it
+        let Options {
+            start,
+            end,
+            limit,
+            status,
+        } = options;
+
         Self {
-            start: &options.start,
-            end: &options.end,
-            limit: options.limit,
-            status: match options.status {
+            start,
+            end,
+            limit: *limit,
+            status: match status {
                 Some(Status::Succeeded) => Some("succeeded"),
                 Some(Status::Failed) => Some("failed"),
                 None => None,

--- a/src/usage/list_requests_options.rs
+++ b/src/usage/list_requests_options.rs
@@ -12,9 +12,9 @@ use serde::Serialize;
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#usage-all
 #[derive(Debug, PartialEq, Clone)]
-pub struct Options<'a> {
-    start: Option<&'a str>,
-    end: Option<&'a str>,
+pub struct Options {
+    start: Option<String>,
+    end: Option<String>,
     limit: Option<usize>,
     status: Option<Status>,
 }
@@ -34,31 +34,31 @@ pub enum Status {
 ///
 /// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 #[derive(Debug, PartialEq, Clone)]
-pub struct OptionsBuilder<'a>(Options<'a>);
+pub struct OptionsBuilder(Options);
 
 #[derive(Serialize)]
 pub(super) struct SerializableOptions<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    start: Option<&'a str>,
+    start: &'a Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    end: Option<&'a str>,
+    end: &'a Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<usize>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    status: Option<&'a str>,
+    status: Option<&'static str>,
 }
 
-impl<'a> Options<'a> {
+impl Options {
     /// Construct a new [`OptionsBuilder`].
-    pub fn builder() -> OptionsBuilder<'a> {
+    pub fn builder() -> OptionsBuilder {
         OptionsBuilder::new()
     }
 }
 
-impl<'a> OptionsBuilder<'a> {
+impl OptionsBuilder {
     /// Construct a new [`OptionsBuilder`].
     pub fn new() -> Self {
         Self(Options {
@@ -80,8 +80,8 @@ impl<'a> OptionsBuilder<'a> {
     ///     .start("1970-01-01")
     ///     .build();
     /// ```
-    pub fn start(mut self, start: &'a str) -> Self {
-        self.0.start = Some(start);
+    pub fn start(mut self, start: impl Into<String>) -> Self {
+        self.0.start = Some(start.into());
         self
     }
 
@@ -96,8 +96,8 @@ impl<'a> OptionsBuilder<'a> {
     ///     .end("2038-01-19")
     ///     .build();
     /// ```
-    pub fn end(mut self, end: &'a str) -> Self {
-        self.0.end = Some(end);
+    pub fn end(mut self, end: impl Into<String>) -> Self {
+        self.0.end = Some(end.into());
         self
     }
 
@@ -134,22 +134,22 @@ impl<'a> OptionsBuilder<'a> {
     }
 
     /// Finish building the [`Options`] object.
-    pub fn build(self) -> Options<'a> {
+    pub fn build(self) -> Options {
         self.0
     }
 }
 
-impl Default for OptionsBuilder<'_> {
+impl Default for OptionsBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a> From<&'a Options<'a>> for SerializableOptions<'a> {
-    fn from(options: &'a Options<'a>) -> Self {
+impl<'a> From<&'a Options> for SerializableOptions<'a> {
+    fn from(options: &'a Options) -> Self {
         Self {
-            start: options.start,
-            end: options.end,
+            start: &options.start,
+            end: &options.end,
             limit: options.limit,
             status: match options.status {
                 Some(Status::Succeeded) => Some("succeeded"),


### PR DESCRIPTION
If types contain a `&'a str`, there lifetime is limited to `'a`. This is frustrating when the user would like the type to have a `'static` lifetime. Storing the data as a `String` instead fixes this problem because `String`s always have a `'static` lifetime. There will be some overhead associated with this change, but it will almost always be negligible.

[This has been discussed before](https://github.com/deepgram-devs/deepgram-rust-sdk/pull/1#discussion_r879829601), but I've been putting it off until all the branches have been consolidated in order to avoid a million merge conflicts. Well, that day is today.