### PR TITLE
fix(streaming): hard-coded uri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepgram"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 authors = ["Deepgram <developers@deepgram.com>"]
 edition = "2021"
 description = "Official Rust SDK for Deepgram's automated speech recognition APIs."

--- a/src/transcription/live.rs
+++ b/src/transcription/live.rs
@@ -220,21 +220,22 @@ where
 
         // This unwrap is safe because we're parsing a static.
         let mut base = Url::parse("wss://api.deepgram.com/v1/listen").unwrap();
-        let mut pairs = base.query_pairs_mut();
-        if let Some(encoding) = encoding {
-            pairs.append_pair("encoding", &encoding);
-        }
-        if let Some(sample_rate) = sample_rate {
-            pairs.append_pair("sample_rate", &sample_rate.to_string());
-        }
-        if let Some(channels) = channels {
-            pairs.append_pair("channels", &channels.to_string());
+        {
+            let mut pairs = base.query_pairs_mut();
+            if let Some(encoding) = encoding {
+                pairs.append_pair("encoding", &encoding);
+            }
+            if let Some(sample_rate) = sample_rate {
+                pairs.append_pair("sample_rate", &sample_rate.to_string());
+            }
+            if let Some(channels) = channels {
+                pairs.append_pair("channels", &channels.to_string());
+            }
         }
 
         let request = Request::builder()
             .method("GET")
-            // TODO Hard-coded.
-            .uri("wss://api.deepgram.com/v1/listen?encoding=linear16&sample_rate=44100&channels=2")
+            .uri(base.to_string())
             .header(
                 "authorization",
                 format!("token {}", config.api_key.as_ref()),


### PR DESCRIPTION
We build a URI to use with the user's specified
encoding/sample_rate/channels, but we never used it.

This also fixes an issue by making the future returned by `start()` `Send`.

Fixes #45

<!-- 
############################################# NOTICE #############################################

For the majority of situations, please use the dev branch as the base for your pull request.
We only update the main branch when we release a new version of the package.

More info: https://github.com/deepgram-devs/deepgram-rust-sdk/wiki/Branches

##################################################################################################
-->

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Types of changes

<!-- What types of changes does your code introduce to the Deepgram Rust SDK? -->

<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

<!-- You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

<!-- Put an `x` in the boxes that apply. -->
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) doc
- [ ] I have added tests and/or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
