### PR TITLE
refactor!: remove generic from `Deepgram`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Remove generic from `Deepgram` struct.
+
 ## [0.3.0]
 
 ### Added
@@ -16,4 +21,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use Rustls instead of OpenSSL.
 
+[Unreleased]: https://github.com/deepgram-devs/deepgram-rust-sdk/compare/0.3.0...HEAD
 [0.3.0]: https://github.com/deepgram-devs/deepgram-rust-sdk/compare/0.2.1...0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepgram"
-version = "0.3.0"
+version = "0.4.0-alpha.1"
 authors = ["Deepgram <developers@deepgram.com>"]
 edition = "2021"
 description = "Official Rust SDK for Deepgram's automated speech recognition APIs."

--- a/src/billing.rs
+++ b/src/billing.rs
@@ -18,23 +18,23 @@ use response::{Balance, Balances};
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#billing
 #[derive(Debug, Clone)]
-pub struct Billing<'a, K: AsRef<str>>(&'a Deepgram<K>);
+pub struct Billing<'a>(&'a Deepgram);
 
-impl<'a, K: AsRef<str>> Deepgram<K> {
+impl Deepgram {
     /// Construct a new [`Billing`] from a [`Deepgram`].
-    pub fn billing(&'a self) -> Billing<'a, K> {
+    pub fn billing(&self) -> Billing<'_> {
         self.into()
     }
 }
 
-impl<'a, K: AsRef<str>> From<&'a Deepgram<K>> for Billing<'a, K> {
+impl<'a> From<&'a Deepgram> for Billing<'a> {
     /// Construct a new [`Billing`] from a [`Deepgram`].
-    fn from(deepgram: &'a Deepgram<K>) -> Self {
+    fn from(deepgram: &'a Deepgram) -> Self {
         Self(deepgram)
     }
 }
 
-impl<K: AsRef<str>> Billing<'_, K> {
+impl Billing<'_> {
     /// Get the outstanding balances for the specified project.
     ///
     /// See the [Deepgram API Reference][api] for more info.

--- a/src/invitations.rs
+++ b/src/invitations.rs
@@ -18,23 +18,23 @@ use response::Message;
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#invitations
 #[derive(Debug, Clone)]
-pub struct Invitations<'a, K: AsRef<str>>(&'a Deepgram<K>);
+pub struct Invitations<'a>(&'a Deepgram);
 
-impl<'a, K: AsRef<str>> Deepgram<K> {
+impl Deepgram {
     /// Construct a new [`Invitations`] from a [`Deepgram`].
-    pub fn invitations(&'a self) -> Invitations<'a, K> {
+    pub fn invitations(&self) -> Invitations<'_> {
         self.into()
     }
 }
 
-impl<'a, K: AsRef<str>> From<&'a Deepgram<K>> for Invitations<'a, K> {
+impl<'a> From<&'a Deepgram> for Invitations<'a> {
     /// Construct a new [`Invitations`] from a [`Deepgram`].
-    fn from(deepgram: &'a Deepgram<K>) -> Self {
+    fn from(deepgram: &'a Deepgram) -> Self {
         Self(deepgram)
     }
 }
 
-impl<K: AsRef<str>> Invitations<'_, K> {
+impl Invitations<'_> {
     /// Remove the authenticated account from the specified project.
     ///
     /// See the [Deepgram API Reference][api] for more info.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -20,23 +20,23 @@ use response::{MemberAndApiKey, MembersAndApiKeys, Message, NewApiKey};
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#keys
 #[derive(Debug, Clone)]
-pub struct Keys<'a, K: AsRef<str>>(&'a Deepgram<K>);
+pub struct Keys<'a>(&'a Deepgram);
 
-impl<'a, K: AsRef<str>> Deepgram<K> {
+impl Deepgram {
     /// Construct a new [`Keys`] from a [`Deepgram`].
-    pub fn keys(&'a self) -> Keys<'a, K> {
+    pub fn keys(&self) -> Keys<'_> {
         self.into()
     }
 }
 
-impl<'a, K: AsRef<str>> From<&'a Deepgram<K>> for Keys<'a, K> {
+impl<'a> From<&'a Deepgram> for Keys<'a> {
     /// Construct a new [`Keys`] from a [`Deepgram`].
-    fn from(deepgram: &'a Deepgram<K>) -> Self {
+    fn from(deepgram: &'a Deepgram) -> Self {
         Self(deepgram)
     }
 }
 
-impl<'a, K: AsRef<str>> Keys<'_, K> {
+impl Keys<'_> {
     /// Get keys for the specified project.
     ///
     /// See the [Deepgram API Reference][api] for more info.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,8 @@ mod response;
 ///
 /// Make transcriptions requests using [`Deepgram::transcription`].
 #[derive(Debug, Clone)]
-pub struct Deepgram<K>
-where
-    K: AsRef<str>,
-{
-    api_key: K,
+pub struct Deepgram {
+    api_key: String,
     client: reqwest::Client,
 }
 
@@ -79,10 +76,7 @@ pub enum DeepgramError {
 
 type Result<T> = std::result::Result<T, DeepgramError>;
 
-impl<K> Deepgram<K>
-where
-    K: AsRef<str>,
-{
+impl Deepgram {
     /// Construct a new Deepgram client.
     ///
     /// Create your first API key on the [Deepgram Console][console].
@@ -92,7 +86,7 @@ where
     /// # Panics
     ///
     /// Panics under the same conditions as [`reqwest::Client::new`].
-    pub fn new(api_key: K) -> Self {
+    pub fn new<K: AsRef<str>>(api_key: K) -> Self {
         static USER_AGENT: &str = concat!(
             env!("CARGO_PKG_NAME"),
             "/",
@@ -109,6 +103,7 @@ where
             );
             header
         };
+        let api_key = api_key.as_ref().to_owned();
 
         Deepgram {
             api_key,

--- a/src/members.rs
+++ b/src/members.rs
@@ -16,23 +16,23 @@ pub mod response;
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#members
 #[derive(Debug, Clone)]
-pub struct Members<'a, K: AsRef<str>>(&'a Deepgram<K>);
+pub struct Members<'a>(&'a Deepgram);
 
-impl<'a, K: AsRef<str>> Deepgram<K> {
+impl Deepgram {
     /// Construct a new [`Members`] from a [`Deepgram`].
-    pub fn members(&'a self) -> Members<'a, K> {
+    pub fn members(&self) -> Members<'_> {
         self.into()
     }
 }
 
-impl<'a, K: AsRef<str>> From<&'a Deepgram<K>> for Members<'a, K> {
+impl<'a> From<&'a Deepgram> for Members<'a> {
     /// Construct a new [`Members`] from a [`Deepgram`].
-    fn from(deepgram: &'a Deepgram<K>) -> Self {
+    fn from(deepgram: &'a Deepgram) -> Self {
         Self(deepgram)
     }
 }
 
-impl<K: AsRef<str>> Members<'_, K> {
+impl Members<'_> {
     /// Get all members of the specified project.
     ///
     /// See the [Deepgram API Reference][api] for more info.

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -23,23 +23,23 @@ use response::{Message, Project};
 /// [console]: https://console.deepgram.com/
 /// [api]: https://developers.deepgram.com/api-reference/#projects
 #[derive(Debug, Clone)]
-pub struct Projects<'a, K: AsRef<str>>(&'a Deepgram<K>);
+pub struct Projects<'a>(&'a Deepgram);
 
-impl<'a, K: AsRef<str>> Deepgram<K> {
+impl Deepgram {
     /// Construct a new [`Projects`] from a [`Deepgram`].
-    pub fn projects(&'a self) -> Projects<'a, K> {
+    pub fn projects(&self) -> Projects<'_> {
         self.into()
     }
 }
 
-impl<'a, K: AsRef<str>> From<&'a Deepgram<K>> for Projects<'a, K> {
+impl<'a> From<&'a Deepgram> for Projects<'a> {
     /// Construct a new [`Projects`] from a [`Deepgram`].
-    fn from(deepgram: &'a Deepgram<K>) -> Self {
+    fn from(deepgram: &'a Deepgram) -> Self {
         Self(deepgram)
     }
 }
 
-impl<'a, K: AsRef<str>> Projects<'_, K> {
+impl Projects<'_> {
     /// Get all projects.
     ///
     /// See the [Deepgram API Reference][api] for more info.

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -20,23 +20,23 @@ use response::Message;
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#scopes
 #[derive(Debug, Clone)]
-pub struct Scopes<'a, K: AsRef<str>>(&'a Deepgram<K>);
+pub struct Scopes<'a>(&'a Deepgram);
 
-impl<'a, K: AsRef<str>> Deepgram<K> {
+impl Deepgram {
     /// Construct a new [`Scopes`] from a [`Deepgram`].
-    pub fn scopes(&'a self) -> Scopes<'a, K> {
+    pub fn scopes(&self) -> Scopes<'_> {
         self.into()
     }
 }
 
-impl<'a, K: AsRef<str>> From<&'a Deepgram<K>> for Scopes<'a, K> {
+impl<'a> From<&'a Deepgram> for Scopes<'a> {
     /// Construct a new [`Scopes`] from a [`Deepgram`].
-    fn from(deepgram: &'a Deepgram<K>) -> Self {
+    fn from(deepgram: &'a Deepgram) -> Self {
         Self(deepgram)
     }
 }
 
-impl<K: AsRef<str>> Scopes<'_, K> {
+impl Scopes<'_> {
     /// Get the specified project scopes assigned to the specified member.
     ///
     /// See the [Deepgram API Reference][api] for more info.

--- a/src/transcription.rs
+++ b/src/transcription.rs
@@ -17,18 +17,18 @@ pub mod prerecorded;
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#transcription
 #[derive(Debug, Clone)]
-pub struct Transcription<'a, K: AsRef<str>>(&'a Deepgram<K>);
+pub struct Transcription<'a>(&'a Deepgram);
 
-impl<'a, K: AsRef<str>> Deepgram<K> {
+impl Deepgram {
     /// Construct a new [`Transcription`] from a [`Deepgram`].
-    pub fn transcription(&'a self) -> Transcription<'a, K> {
+    pub fn transcription(&self) -> Transcription<'_> {
         self.into()
     }
 }
 
-impl<'a, K: AsRef<str>> From<&'a Deepgram<K>> for Transcription<'a, K> {
+impl<'a> From<&'a Deepgram> for Transcription<'a> {
     /// Construct a new [`Transcription`] from a [`Deepgram`].
-    fn from(deepgram: &'a Deepgram<K>) -> Self {
+    fn from(deepgram: &'a Deepgram) -> Self {
         Self(deepgram)
     }
 }

--- a/src/transcription/prerecorded.rs
+++ b/src/transcription/prerecorded.rs
@@ -19,7 +19,7 @@ use response::{CallbackResponse, Response};
 
 static DEEPGRAM_API_URL_LISTEN: &str = "https://api.deepgram.com/v1/listen";
 
-impl<K: AsRef<str>> Transcription<'_, K> {
+impl Transcription<'_> {
     /// Sends a request to Deepgram to transcribe pre-recorded audio.
     /// If you wish to use the Callback feature, you should use [`Transcription::prerecorded_callback`] instead.
     ///

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -21,23 +21,23 @@ use response::{Fields, Request, Requests, UsageSummary};
 ///
 /// [api]: https://developers.deepgram.com/api-reference/#usage
 #[derive(Debug, Clone)]
-pub struct Usage<'a, K: AsRef<str>>(&'a Deepgram<K>);
+pub struct Usage<'a>(&'a Deepgram);
 
-impl<'a, K: AsRef<str>> Deepgram<K> {
+impl Deepgram {
     /// Construct a new [`Usage`] from a [`Deepgram`].
-    pub fn usage(&'a self) -> Usage<'a, K> {
+    pub fn usage(&self) -> Usage<'_> {
         self.into()
     }
 }
 
-impl<'a, K: AsRef<str>> From<&'a Deepgram<K>> for Usage<'a, K> {
+impl<'a> From<&'a Deepgram> for Usage<'a> {
     /// Construct a new [`Usage`] from a [`Deepgram`].
-    fn from(deepgram: &'a Deepgram<K>) -> Self {
+    fn from(deepgram: &'a Deepgram) -> Self {
         Self(deepgram)
     }
 }
 
-impl<'a, K: AsRef<str>> Usage<'_, K> {
+impl Usage<'_> {
     /// Get all requests sent to the Deepgram API for the specified project.
     ///
     /// See the [Deepgram API Reference][api] for more info.


### PR DESCRIPTION
The `Deepgram` struct is unnecessarily generic. Storing the API key as a generic offers flexibility which probably isn't warranted by any use cases.

Fixes #49

<!-- 
############################################# NOTICE #############################################

For the majority of situations, please use the dev branch as the base for your pull request.
We only update the main branch when we release a new version of the package.

More info: https://github.com/deepgram-devs/deepgram-rust-sdk/wiki/Branches

##################################################################################################
-->

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Types of changes

<!-- What types of changes does your code introduce to the Deepgram Rust SDK? -->

<!-- Put an `x` in the boxes that apply -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

<!-- You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

<!-- Put an `x` in the boxes that apply. -->
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) doc
- [ ] I have added tests and/or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
