### PR TITLE
Add detect_language feature to Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `detect_language` option.
+
 ## [0.3.0]
 
 ### Added
@@ -16,4 +21,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use Rustls instead of OpenSSL.
 
+[Unreleased]: https://github.com/deepgram-devs/deepgram-rust-sdk/compare/0.3.0...HEAD
 [0.3.0]: https://github.com/deepgram-devs/deepgram-rust-sdk/compare/0.2.1...0.3.0

--- a/src/transcription/prerecorded/options.rs
+++ b/src/transcription/prerecorded/options.rs
@@ -27,6 +27,7 @@ pub struct Options {
     keyword_boost_legacy: bool,
     utterances: Option<Utterances>,
     tags: Vec<String>,
+    detect_language: Option<bool>,
 }
 
 /// Used as a parameter for [`OptionsBuilder::tier`].
@@ -282,6 +283,7 @@ impl OptionsBuilder {
             keyword_boost_legacy: false,
             utterances: None,
             tags: Vec::new(),
+            detect_language: None,
         })
     }
 
@@ -1052,6 +1054,26 @@ impl OptionsBuilder {
         self
     }
 
+    /// Set the Language Detection feature.
+    ///
+    /// See the [Deepgram Language Detection feature docs][docs] for more info.
+    ///
+    /// [docs]: https://developers.deepgram.com/docs/language-detection/
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use deepgram::transcription::prerecorded::options::Options;
+    /// #
+    /// let options = Options::builder()
+    ///     .detect_language(true)
+    ///     .build();
+    /// ```
+    pub fn detect_language(mut self, detect_language: bool) -> Self {
+        self.0.detect_language = Some(detect_language);
+
+        self
+    }
     /// Finish building the [`Options`] object.
     pub fn build(self) -> Options {
         self.0
@@ -1091,6 +1113,7 @@ impl Serialize for SerializableOptions<'_> {
             keyword_boost_legacy,
             utterances,
             tags,
+            detect_language,
         } = self.0;
 
         if let Some(tier) = tier {
@@ -1202,6 +1225,10 @@ impl Serialize for SerializableOptions<'_> {
 
         for element in tags {
             seq.serialize_element(&("tag", element))?;
+        }
+
+        if let Some(detect_language) = detect_language {
+            seq.serialize_element(&("detect_language", detect_language))?;
         }
 
         seq.end()
@@ -1721,6 +1748,19 @@ mod serialize_options_tests {
         check_serialization(
             &Options::builder().tag(["Tag 1", "Tag 2"]).build(),
             "tag=Tag+1&tag=Tag+2",
+        );
+    }
+
+    #[test]
+    fn detect_language() {
+        check_serialization(
+            &Options::builder().detect_language(false).build(),
+            "detect_language=false",
+        );
+
+        check_serialization(
+            &Options::builder().detect_language(true).build(),
+            "detect_language=true",
         );
     }
 }

--- a/src/transcription/prerecorded/response.rs
+++ b/src/transcription/prerecorded/response.rs
@@ -97,6 +97,15 @@ pub struct ChannelResult {
 
     #[allow(missing_docs)]
     pub alternatives: Vec<ResultAlternative>,
+
+    ///  [BCP-47][bcp47] language tag for the dominant language identified in the channel.
+    ///
+    /// [`None`] unless the [Language Detection feature][docs] is set.
+    /// Features can be set using an [`OptionsBuilder`](`super::options::OptionsBuilder`).
+    ///
+    /// [bcp47]: https://tools.ietf.org/html/bcp47
+    /// [docs]: https://developers.deepgram.com/docs/language-detection/
+    pub detected_language: Option<String>,
 }
 
 /// Transcription results for a single utterance.


### PR DESCRIPTION
The feature exists in the API, but is not exposed in the SDK.

Fix #51

## Proposed changes

Adds some missing API to the SDK.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) doc
- [x] I have added tests and/or examples that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
