### PR TITLE
Custom hosts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 use std::io;
 
+use redacted::RedactedString;
 use reqwest::{
     header::{HeaderMap, HeaderValue},
     RequestBuilder,
@@ -21,11 +22,11 @@ pub mod invitations;
 pub mod keys;
 pub mod members;
 pub mod projects;
+mod redacted;
+mod response;
 pub mod scopes;
 pub mod transcription;
 pub mod usage;
-
-mod response;
 
 static DEEPGRAM_BASE_URL: &str = "https://api.deepgram.com";
 
@@ -35,7 +36,7 @@ static DEEPGRAM_BASE_URL: &str = "https://api.deepgram.com";
 #[derive(Debug, Clone)]
 pub struct Deepgram {
     #[cfg_attr(not(feature = "live"), allow(unused))]
-    api_key: Option<String>,
+    api_key: Option<RedactedString>,
     #[cfg_attr(not(any(feature = "live", feature = "prerecorded")), allow(unused))]
     base_url: Url,
     client: reqwest::Client,
@@ -197,7 +198,7 @@ impl Deepgram {
         };
 
         Deepgram {
-            api_key,
+            api_key: api_key.map(RedactedString),
             base_url,
             client: reqwest::Client::builder()
                 .user_agent(USER_AGENT)

--- a/src/redacted.rs
+++ b/src/redacted.rs
@@ -1,0 +1,18 @@
+use std::{fmt, ops::Deref};
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct RedactedString(pub String);
+
+impl fmt::Debug for RedactedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("***")
+    }
+}
+
+impl Deref for RedactedString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/transcription/live.rs
+++ b/src/transcription/live.rs
@@ -30,6 +30,8 @@ use crate::{Deepgram, DeepgramError, Result};
 
 use super::Transcription;
 
+static LIVE_LISTEN_URL_PATH: &str = "v1/listen";
+
 #[derive(Debug)]
 pub struct StreamRequestBuilder<'a, S, E>
 where
@@ -40,6 +42,7 @@ where
     encoding: Option<String>,
     sample_rate: Option<u32>,
     channels: Option<u16>,
+    stream_url: Url,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -95,7 +98,18 @@ impl Transcription<'_> {
             encoding: None,
             sample_rate: None,
             channels: None,
+            stream_url: self.listen_stream_url(),
         }
+    }
+
+    fn listen_stream_url(&self) -> Url {
+        let mut url = self.0.base_url.join(LIVE_LISTEN_URL_PATH).unwrap();
+        match url.scheme() {
+            "http" | "ws" => url.set_scheme("ws").unwrap(),
+            "https" | "wss" => url.set_scheme("wss").unwrap(),
+            _ => panic!("base_url must have a scheme of http, https, ws, or wss"),
+        }
+        url
     }
 }
 
@@ -201,36 +215,30 @@ where
     E: Send + std::fmt::Debug,
 {
     pub async fn start(self) -> Result<Receiver<Result<StreamResponse>>> {
-        let StreamRequestBuilder {
-            config,
-            source,
-            encoding,
-            sample_rate,
-            channels,
-        } = self;
-        let mut source = source
-            .ok_or(DeepgramError::NoSource)?
-            .map(|res| res.map(|bytes| Message::binary(Vec::from(bytes.as_ref()))));
-
         // This unwrap is safe because we're parsing a static.
-        let mut base = Url::parse("wss://api.deepgram.com/v1/listen").unwrap();
+        let mut url = self.stream_url;
         {
-            let mut pairs = base.query_pairs_mut();
-            if let Some(encoding) = encoding {
-                pairs.append_pair("encoding", &encoding);
+            let mut pairs = url.query_pairs_mut();
+            if let Some(encoding) = &self.encoding {
+                pairs.append_pair("encoding", encoding);
             }
-            if let Some(sample_rate) = sample_rate {
+            if let Some(sample_rate) = self.sample_rate {
                 pairs.append_pair("sample_rate", &sample_rate.to_string());
             }
-            if let Some(channels) = channels {
+            if let Some(channels) = self.channels {
                 pairs.append_pair("channels", &channels.to_string());
             }
         }
 
+        let mut source = self
+            .source
+            .ok_or(DeepgramError::NoSource)?
+            .map(|res| res.map(|bytes| Message::binary(Vec::from(bytes.as_ref()))));
+
         let request = Request::builder()
             .method("GET")
-            .uri(base.to_string())
-            .header("authorization", format!("token {}", config.api_key))
+            .uri(url.to_string())
+            .header("authorization", format!("token {}", self.config.api_key))
             .header("sec-websocket-key", client::generate_key())
             .header("host", "api.deepgram.com")
             .header("connection", "upgrade")
@@ -286,5 +294,26 @@ where
         });
 
         Ok(rx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_stream_url() {
+        let dg = crate::Deepgram::new("token");
+        assert_eq!(
+            dg.transcription().listen_stream_url().to_string(),
+            "wss://api.deepgram.com/v1/listen",
+        );
+    }
+
+    #[test]
+    fn test_stream_url_custom_host() {
+        let dg = crate::Deepgram::with_base_url("token", "http://localhost:8080");
+        assert_eq!(
+            dg.transcription().listen_stream_url().to_string(),
+            "ws://localhost:8080/v1/listen",
+        );
     }
 }

--- a/src/transcription/prerecorded.rs
+++ b/src/transcription/prerecorded.rs
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn listen_url_custom_host() {
-        let dg = Deepgram::with_base_url("token", "http://localhost:8888/abc/");
+        let dg = Deepgram::with_base_url("http://localhost:8888/abc/");
         assert_eq!(
             &dg.transcription().listen_url().to_string(),
             "http://localhost:8888/abc/v1/listen"


### PR DESCRIPTION
<!-- 
############################################# NOTICE #############################################

For the majority of situations, please use the dev branch as the base for your pull request.
We only update the main branch when we release a new version of the package.

More info: https://github.com/deepgram-devs/deepgram-rust-sdk/wiki/Branches

##################################################################################################
-->

## Proposed changes

Support connecting to deepgram hosts at URLs other than `https://api.deepgram.com`.  This will help us support self-hosted users, as well as supporting in-house development.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Types of changes

<!-- What types of changes does your code introduce to the Deepgram Rust SDK? -->

<!-- Put an `x` in the boxes that apply -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

<!-- You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

<!-- Put an `x` in the boxes that apply. -->
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) doc
- [x] I have added tests and/or examples that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
