### PR TITLE
crates.io rejects more than 5 keywords to avoid keyword spamming.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "Official Rust SDK for Deepgram's automated speech recognition APIs."
 license = "MIT"
 repository = "https://github.com/deepgram-devs/deepgram-rust-sdk"
-keywords = ["deepgram", "transcription", "voice ai", "text-to-speech", "tts", "aura", "speech-to-text", "stt", "asr", "nova", "voice agent", "self-hosted"]
+keywords = ["transcription", "voice-ai", "text-to-speech", "speech-to-text","asr"]
 categories = ["api-bindings", "multimedia::audio"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Spaces are also forbidden in keywords.

I published the 0.6.0 release with this proposed version.  Open to
discussion about what keywords we should be using.
