### PR TITLE
Implement `From<String>` for `Model`, `Language`, and `Redact`

### DIFF
--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -2227,10 +2227,10 @@ impl AsRef<str> for Model {
 impl From<String> for Model {
     fn from(value: String) -> Self {
         match &*value {
-            "nova-2" => Self::Nova2,
-            "nova" => Self::Nova,
-            "enhanced" => Self::Enhanced,
-            "base" => Self::Base,
+            "nova-2" | "nova-2-general" => Self::Nova2,
+            "nova" | "nova-general"  => Self::Nova,
+            "enhanced" | "enhanced-general" => Self::Enhanced,
+            "base" | "base-general" => Self::Base,
             "nova-2-meeting" => Self::Nova2Meeting,
             "nova-2-phonecall" => Self::Nova2Phonecall,
             "nova-2-finance" => Self::Nova2Finance,

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -2425,6 +2425,32 @@ fn models_to_string(models: &[Model]) -> String {
 }
 
 #[cfg(test)]
+mod from_string_tests {
+    use super::{Language, Model, Redact};
+
+    #[test]
+    fn model_from_string() {
+        assert_eq!(Model::from("nova-2".to_string()), Model::Nova2);
+        assert_eq!(Model::from("custom".to_string()), Model::CustomId("custom".to_string()));
+        assert_eq!(Model::from("".to_string()), Model::CustomId("".to_string()));
+    }
+
+    #[test]
+    fn language_from_string() {
+        assert_eq!(Language::from("zh-Hant".to_string()), Language::zh_Hant);
+        assert_eq!(Language::from("custom".to_string()), Language::Other("custom".to_string()));
+        assert_eq!(Language::from("".to_string()), Language::Other("".to_string()));
+    }
+
+    #[test]
+    fn redact_from_string() {
+        assert_eq!(Redact::from("pci".to_string()), Redact::Pci);
+        assert_eq!(Redact::from("custom".to_string()), Redact::Other("custom".to_string()));
+        assert_eq!(Redact::from("".to_string()), Redact::Other("".to_string()));
+    }
+
+}
+#[cfg(test)]
 mod models_to_string_tests {
     use super::*;
 

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -2224,6 +2224,52 @@ impl AsRef<str> for Model {
     }
 }
 
+impl From<String> for Model {
+    fn from(value: String) -> Self {
+        match &*value {
+            "nova-2" => Self::Nova2,
+            "nova" => Self::Nova,
+            "enhanced" => Self::Enhanced,
+            "base" => Self::Base,
+            "nova-2-meeting" => Self::Nova2Meeting,
+            "nova-2-phonecall" => Self::Nova2Phonecall,
+            "nova-2-finance" => Self::Nova2Finance,
+            "nova-2-conversationalai" => Self::Nova2Conversationalai,
+            "nova-2-voicemail" => Self::Nova2Voicemail,
+            "nova-2-video" => Self::Nova2Video,
+            "nova-2-medical" => Self::Nova2Medical,
+            "nova-2-drivethru" => Self::Nova2Drivethru,
+            "nova-2-automotive" => Self::Nova2Automotive,
+            "nova-phonecall" => Self::NovaPhonecall,
+            "nova-medical" => Self::NovaMedical,
+            "enhanced-meeting" => Self::EnhancedMeeting,
+            "enhanced-phonecall" => Self::EnhancedPhonecall,
+            "enhanced-finance" => Self::EnhancedFinance,
+            "base-meeting" => Self::BaseMeeting,
+            "base-phonecall" => Self::BasePhonecall,
+            "base-voicemail" => Self::BaseVoicemail,
+            "base-finance" => Self::BaseFinance,
+            "base-conversationalai" => Self::BaseConversationalai,
+            "base-video" => Self::BaseVideo,
+            #[allow(deprecated)]
+            "general" => Self::General,
+            #[allow(deprecated)]
+            "phonecall" => Self::Phonecall,
+            #[allow(deprecated)]
+            "voicemail" => Self::Voicemail,
+            #[allow(deprecated)]
+            "finance" => Self::Finance,
+            #[allow(deprecated)]
+            "meeting" => Self::Meeting,
+            #[allow(deprecated)]
+            "conversationalai" => Self::Conversationalai,
+            #[allow(deprecated)]
+            "video" => Self::Video,
+            _ => Self::CustomId(value),
+        }
+    }
+}
+
 impl AsRef<str> for Language {
     fn as_ref(&self) -> &str {
         match self {
@@ -2286,15 +2332,86 @@ impl AsRef<str> for Language {
     }
 }
 
+impl From<String> for Language {
+    fn from(value: String) -> Language {
+        match &*value {
+            "bg" => Self::bg,
+            "ca" => Self::ca,
+            "cs" => Self::cs,
+            "da" => Self::da,
+            "de" => Self::de,
+            "de-CH" => Self::de_CH,
+            "el" => Self::el,
+            "en" => Self::en,
+            "en-AU" => Self::en_AU,
+            "en-GB" => Self::en_GB,
+            "en-IN" => Self::en_IN,
+            "en-NZ" => Self::en_NZ,
+            "en-US" => Self::en_US,
+            "es" => Self::es,
+            "es-419" => Self::es_419,
+            "es-LATAM" => Self::es_LATAM,
+            "et" => Self::et,
+            "fi" => Self::fi,
+            "fr" => Self::fr,
+            "fr-CA" => Self::fr_CA,
+            "hi" => Self::hi,
+            "hi-Latn" => Self::hi_Latn,
+            "hu" => Self::hu,
+            "id" => Self::id,
+            "it" => Self::it,
+            "ja" => Self::ja,
+            "ko" => Self::ko,
+            "ko-KR" => Self::ko_KR,
+            "lv" => Self::lv,
+            "lt" => Self::lt,
+            "ms" => Self::ms,
+            "nl" => Self::nl,
+            "nl-BE" => Self::nl_BE,
+            "no" => Self::no,
+            "pl" => Self::pl,
+            "pt" => Self::pt,
+            "pt-BR" => Self::pt_BR,
+            "ro" => Self::ro,
+            "ru" => Self::ru,
+            "sk" => Self::sk,
+            "sv" => Self::sv,
+            "sv-SE" => Self::sv_SE,
+            "ta" => Self::ta,
+            "taq" => Self::taq,
+            "th" => Self::th,
+            "th-TH" => Self::th_TH,
+            "tr" => Self::tr,
+            "uk" => Self::uk,
+            "vi" => Self::vi,
+            "zh" => Self::zh,
+            "zh-CN" => Self::zh_CN,
+            "zh-Hans" => Self::zh_Hans,
+            "zh-Hant" => Self::zh_Hant,
+            "zh-TW" => Self::zh_TW,
+            _ => Self::Other(value),
+        }
+    }
+}
+
 impl AsRef<str> for Redact {
     fn as_ref(&self) -> &str {
-        use Redact::*;
-
         match self {
-            Pci => "pci",
-            Numbers => "numbers",
-            Ssn => "ssn",
-            Other(id) => id,
+            Redact::Pci => "pci",
+            Redact::Numbers => "numbers",
+            Redact::Ssn => "ssn",
+            Redact::Other(id) => id,
+        }
+    }
+}
+
+impl From<String> for Redact {
+    fn from(value: String) -> Redact {
+        match &*value {
+            "pci" => Redact::Pci,
+            "numbers" => Redact::Numbers,
+            "ssn" => Redact::Ssn,
+            _ => Redact::Other(value),
         }
     }
 }

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -2228,7 +2228,7 @@ impl From<String> for Model {
     fn from(value: String) -> Self {
         match &*value {
             "nova-2" | "nova-2-general" => Self::Nova2,
-            "nova" | "nova-general"  => Self::Nova,
+            "nova" | "nova-general" => Self::Nova,
             "enhanced" | "enhanced-general" => Self::Enhanced,
             "base" | "base-general" => Self::Base,
             "nova-2-meeting" => Self::Nova2Meeting,

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -2431,24 +2431,35 @@ mod from_string_tests {
     #[test]
     fn model_from_string() {
         assert_eq!(Model::from("nova-2".to_string()), Model::Nova2);
-        assert_eq!(Model::from("custom".to_string()), Model::CustomId("custom".to_string()));
+        assert_eq!(
+            Model::from("custom".to_string()),
+            Model::CustomId("custom".to_string())
+        );
         assert_eq!(Model::from("".to_string()), Model::CustomId("".to_string()));
     }
 
     #[test]
     fn language_from_string() {
         assert_eq!(Language::from("zh-Hant".to_string()), Language::zh_Hant);
-        assert_eq!(Language::from("custom".to_string()), Language::Other("custom".to_string()));
-        assert_eq!(Language::from("".to_string()), Language::Other("".to_string()));
+        assert_eq!(
+            Language::from("custom".to_string()),
+            Language::Other("custom".to_string())
+        );
+        assert_eq!(
+            Language::from("".to_string()),
+            Language::Other("".to_string())
+        );
     }
 
     #[test]
     fn redact_from_string() {
         assert_eq!(Redact::from("pci".to_string()), Redact::Pci);
-        assert_eq!(Redact::from("custom".to_string()), Redact::Other("custom".to_string()));
+        assert_eq!(
+            Redact::from("custom".to_string()),
+            Redact::Other("custom".to_string())
+        );
         assert_eq!(Redact::from("".to_string()), Redact::Other("".to_string()));
     }
-
 }
 #[cfg(test)]
 mod models_to_string_tests {


### PR DESCRIPTION
<!-- 
############################################# NOTICE #############################################

For the majority of situations, please use the dev branch as the base for your pull request.
We only update the main branch when we release a new version of the package.

More info: https://github.com/deepgram-devs/deepgram-rust-sdk/wiki/Branches

##################################################################################################
-->

## Proposed changes

Add an option to convert strings to various enumerated query options infallibly using `From<String>`.

## Types of changes

<!-- What types of changes does your code introduce to the Deepgram Rust SDK? -->

<!-- Put an `x` in the boxes that apply -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

<!-- You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

<!-- Put an `x` in the boxes that apply. -->
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) doc
- [x] I have added tests and/or examples that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

A customer has requested this feature.  It is not the default way to specify the options, because we want to encourage customers to do it in a type-safe manner using the enum where possible.  To use this version, one can simply do:

```rust
Options::builder()
    .model(String::from("nova-2").into())
    .build()
```

(Normally, one would probably have a `String` to begin with, if it were coming from a runtime input value, so the `String::from` call would not be needed.  If it is being created directly in code, the existing enum should be used directly.

```rust
Options::builder()
    .model(Model::Nova2)
    .build()
```