### PR TITLE
chore: release 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2](https://github.com/deepgram/deepgram-rust-sdk/compare/0.9.1...0.9.2)
+
+### Fixed
+
+- Fix occasional panic in WebSocket keep-alive when `close_stream()` closes the internal channel before the worker's keep-alive timer fires ([#143](https://github.com/deepgram/deepgram-rust-sdk/issues/143)).
+
+### Added
+
+- New example `16_keepalive_close_stream` demonstrating correct keep-alive + close_stream usage.
+
 ## [0.9.1](https://github.com/deepgram/deepgram-rust-sdk/compare/0.9.0...0.9.1)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deepgram"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "audio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepgram"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Deepgram <developers@deepgram.com>"]
 edition = "2021"
 description = "Community Rust SDK for Deepgram's automated speech recognition APIs."


### PR DESCRIPTION
## Summary

- Bump version to 0.9.2
- Update CHANGELOG with keep-alive panic fix (#143)

## Changes in 0.9.2

### Fixed
- Fix occasional panic in WebSocket keep-alive when `close_stream()` closes the internal channel before the worker's keep-alive timer fires (#143)

### Added
- New example `16_keepalive_close_stream` demonstrating correct keep-alive + close_stream usage