### PR TITLE
chore: add Context7 auto-refresh workflow [no-ci]

### DIFF
--- a/.github/workflows/context7.yml
+++ b/.github/workflows/context7.yml
@@ -1,0 +1,17 @@
+name: Update Context7 Documentation
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update Context7 Documentation
+        id: context7
+        uses: rennf93/upsert-context7@1.1
+        with:
+          operation: refresh


### PR DESCRIPTION
Adds a GitHub Actions workflow to automatically refresh Context7 documentation on each release.

Triggers on: `release` (published) and `workflow_dispatch`.